### PR TITLE
Remove MuxPacket type

### DIFF
--- a/lib/mux/src/lib.rs
+++ b/lib/mux/src/lib.rs
@@ -8,13 +8,6 @@ pub mod codec;
 pub type Headers = Vec<(u8, Vec<u8>)>;
 pub type Contexts = Vec<(Vec<u8>, Vec<u8>)>;
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct MuxPacket {
-    pub tpe: i8,
-    pub tag: Tag,
-    pub buffer: Vec<u8>,
-}
-
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Tag {
     pub end: bool,


### PR DESCRIPTION
This type only served to hold the tag and a buffer that contained
the rest of the message. It doesn't serve a purpose in the model.https://travis-ci.org/bryce-anderson
