### PR TITLE
Unify codec function signatures and naming

### DIFF
--- a/lib/mux/src/codec/mod.rs
+++ b/lib/mux/src/codec/mod.rs
@@ -32,23 +32,25 @@ macro_rules! tryb {
 }
 
 // Synchronously read an entire frame
-pub fn read_message(input: &mut Read) -> io::Result<Message> {
+pub fn read_message<R: Read + ?Sized>(input: &mut R) -> io::Result<Message> {
     let size = {
         let size = tryb!(input.read_i32::<BigEndian>());
         if size < 4 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData, "Invalid mux frame size"
-            ));
+            let msg = format!("Invalid mux frame size: {}. Minimum 4 bytes.", size);
+            return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
         }
-        size as usize
+
+        size as u64
     };
 
-    let tpe = tryb!(input.read_i8());
-    let tag = try!(decode_tag(input));
+    decode_message(input.take(size))
+}
 
-    let mut buf = vec![0;size-4];
-    try!(input.read_exact(&mut buf));
-    let frame = try!(decode_frame(tpe, &buf));
+// Synchronously read an entire frame consuming the entire Read
+pub fn decode_message<R: Read>(mut read: R) -> io::Result<Message> {
+    let tpe = tryb!(read.read_i8());
+    let tag = try!(decode_tag(&mut read));
+    let frame = try!(decode_frame(tpe, &mut read));
 
     Ok(Message {
         tag: tag,
@@ -57,7 +59,7 @@ pub fn read_message(input: &mut Read) -> io::Result<Message> {
 }
 
 // write the Message to the Write
-pub fn encode_message(buffer: &mut Write, msg: &Message) -> io::Result<()> {
+pub fn encode_message<W: Write + ?Sized>(buffer: &mut W, msg: &Message) -> io::Result<()> {
     // the size is the buffer size + the header (id + tag)
     tryb!(buffer.write_i32::<BigEndian>(size::frame_size(&msg.frame) as i32 + 4));
     tryb!(buffer.write_i8(msg.frame.frame_id()));
@@ -68,51 +70,39 @@ pub fn encode_message(buffer: &mut Write, msg: &Message) -> io::Result<()> {
 
 // frame codec functions
 
-pub fn encode_frame(buffer: &mut Write, frame: &MessageFrame) -> io::Result<()> {
+pub fn encode_frame<W: Write + ?Sized>(writer: &mut W, frame: &MessageFrame) -> io::Result<()> {
     match frame {
-        &MessageFrame::Treq(ref f) => encode_treq(buffer, f),
-        &MessageFrame::Rreq(ref f) => encode_rreq(buffer, f),
-        &MessageFrame::Tdispatch(ref f) => encode_tdispatch(buffer, f),
-        &MessageFrame::Rdispatch(ref f) => encode_rdispatch(buffer, f),
-        &MessageFrame::Tinit(ref f) => encode_init(buffer, f),
-        &MessageFrame::Rinit(ref f) => encode_init(buffer, f),
+        &MessageFrame::Treq(ref f) => encode_treq(writer, f),
+        &MessageFrame::Rreq(ref f) => encode_rreq(writer, f),
+        &MessageFrame::Tdispatch(ref f) => encode_tdispatch(writer, f),
+        &MessageFrame::Rdispatch(ref f) => encode_rdispatch(writer, f),
+        &MessageFrame::Tinit(ref f) => encode_init(writer, f),
+        &MessageFrame::Rinit(ref f) => encode_init(writer, f),
         // the following are empty messages
         &MessageFrame::Tping => Ok(()),
         &MessageFrame::Rping => Ok(()),
         &MessageFrame::Tdrain => Ok(()),
         &MessageFrame::Rdrain => Ok(()),
-        &MessageFrame::Tlease(ref d) => {
-            let millis = d.as_secs()*1000 + (((d.subsec_nanos() as f64)/1e6) as u64);
-            tryb!(buffer.write_u8(0));
-            tryb!(buffer.write_u64::<BigEndian>(millis));
-            Ok(())
-        }
-        &MessageFrame::Rerr(ref msg) => {
-            buffer.write_all(msg.as_bytes())
-        }
+        &MessageFrame::Tlease(ref d) => encode_tlease_duration(writer, d),
+        &MessageFrame::Rerr(ref msg) => writer.write_all(msg.as_bytes()),
     }
 }
 
-// Decodes `data` into a frame if type `tpe`
-pub fn decode_frame(tpe: i8, data: &[u8]) -> io::Result<MessageFrame> {
+// Decodes `data` into a frame if type `tpe`, consuming the entire Read
+pub fn decode_frame<R: Read>(tpe: i8, mut reader: R) -> io::Result<MessageFrame> {
     Ok(match tpe {
-        types::TREQ => MessageFrame::Treq(try!(decode_treq(data))),
-        types::RREQ => MessageFrame::Rreq(try!(decode_rreq(data))),
-        types::TDISPATCH => MessageFrame::Tdispatch(try!(decode_tdispatch(data))),
-        types::RDISPATCH => MessageFrame::Rdispatch(try!(decode_rdispatch(data))),
-        types::TINIT => MessageFrame::Tinit(try!(decode_init(data))),
-        types::RINIT => MessageFrame::Rinit(try!(decode_init(data))),
+        types::TREQ => MessageFrame::Treq(try!(decode_treq(reader))),
+        types::RREQ => MessageFrame::Rreq(try!(decode_rreq(reader))),
+        types::TDISPATCH => MessageFrame::Tdispatch(try!(decode_tdispatch(reader))),
+        types::RDISPATCH => MessageFrame::Rdispatch(try!(decode_rdispatch(reader))),
+        types::TINIT => MessageFrame::Tinit(try!(decode_init(reader))),
+        types::RINIT => MessageFrame::Rinit(try!(decode_init(reader))),
         types::TDRAIN => MessageFrame::Tdrain,
         types::RDRAIN => MessageFrame::Rdrain,
         types::TPING => MessageFrame::Tping,
         types::RPING => MessageFrame::Rping,
-        types::TLEASE => {
-            let mut buffer = Cursor::new(data);
-            let _ = try!(buffer.read_u8());
-            let ticks = try!(buffer.read_u64::<BigEndian>());
-            MessageFrame::Tlease(Duration::from_millis(ticks))
-        }
-        types::RERR => MessageFrame::Rerr(try!(decode_rerr(data))),
+        types::TLEASE => MessageFrame::Tlease(try!(decode_tlease_duration(&mut reader))),
+        types::RERR => MessageFrame::Rerr(try!(decode_rerr(reader))),
         other => {
             return Err(
                 io::Error::new(io::ErrorKind::InvalidInput,
@@ -123,14 +113,35 @@ pub fn decode_frame(tpe: i8, data: &[u8]) -> io::Result<MessageFrame> {
 }
 
 
+///////////// Tlease codec function
+
+pub fn decode_tlease_duration<R: Read + ?Sized>(reader: &mut R) -> io::Result<Duration> {
+    let howmuch = try!(reader.read_u8());
+    let ticks = try!(reader.read_u64::<BigEndian>());
+
+    if howmuch == 0 {
+        Ok(Duration::from_millis(ticks))
+    } else {
+        let message = format!("Unknown Tlease 'howmuch' code: {}", howmuch);
+        Err(io::Error::new(ErrorKind::InvalidData, message))
+    }
+}
+
+pub fn encode_tlease_duration<W: Write + ?Sized>(writer: &mut W, d: &Duration) -> io::Result<()> {
+    let millis = d.as_secs()*1000 + (((d.subsec_nanos() as f64)/1e6) as u64);
+    tryb!(writer.write_u8(0));
+    tryb!(writer.write_u64::<BigEndian>(millis));
+    Ok(())
+}
+
 ///////////// Tag codec functions
 
 const TAG_END_MASK: u32 = 1 << 23; // 24th bit of tag
 const TAG_ID_MASK: u32 = !TAG_END_MASK;
 
-pub fn decode_tag<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Tag> {
+pub fn decode_tag<R: Read + ?Sized>(reader: &mut R) -> io::Result<Tag> {
     let mut bts = [0; 3];
-    let _ = try!(buffer.read(&mut bts));
+    let _ = try!(reader.read(&mut bts));
 
     let id = (bts[0] as u32) << 16 |
              (bts[1] as u32) <<  8 |
@@ -143,7 +154,7 @@ pub fn decode_tag<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Tag> {
 }
 
 #[inline]
-pub fn encode_tag(buffer: &mut Write, tag: &Tag) -> io::Result<()> {
+pub fn encode_tag<W: Write + ?Sized>(buffer: &mut W, tag: &Tag) -> io::Result<()> {
     let bytes = {
         let id = tag.id;
         let endbit = if tag.end { 0 } else { 1 };
@@ -157,36 +168,36 @@ pub fn encode_tag(buffer: &mut Write, tag: &Tag) -> io::Result<()> {
 
 ///////////// headers codec functions
 
-pub fn encode_headers(buffer: &mut Write, headers: &Headers) -> io::Result<()> {
+pub fn encode_headers<W: Write + ?Sized>(writer: &mut W, headers: &Headers) -> io::Result<()> {
     if headers.len() > u8::MAX as usize {
         return Err(io::Error::new(
             ErrorKind::InvalidInput, format!("Too many headers: {}", headers.len())
         ));
     }
 
-    try!(buffer.write_u8(headers.len() as u8));
+    try!(writer.write_u8(headers.len() as u8));
 
     for &(ref k, ref v) in headers {
         if v.len() > u8::MAX as usize {
             return Err(io::Error::new(ErrorKind::InvalidInput, "Invalid header size"));
         }
 
-        try!(buffer.write_u8(*k));
-        try!(buffer.write_u8(v.len() as u8));
-        try!(buffer.write_all(v));
+        try!(writer.write_u8(*k));
+        try!(writer.write_u8(v.len() as u8));
+        try!(writer.write_all(v));
     }
     Ok(())
 }
 
-pub fn decode_headers<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Headers> {
-    let len = tryb!(buffer.read_u8()) as usize;
+pub fn decode_headers<R: Read + ?Sized>(reader: &mut R) -> io::Result<Headers> {
+    let len = tryb!(reader.read_u8()) as usize;
     let mut acc = Vec::with_capacity(len);
 
     for _ in 0..len {
-        let key = tryb!(buffer.read_u8());
-        let val_len = tryb!(buffer.read_u8());
+        let key = tryb!(reader.read_u8());
+        let val_len = tryb!(reader.read_u8());
         let mut val = vec![0;val_len as usize];
-        try!(buffer.read_exact(&mut val[..]));
+        try!(reader.read_exact(&mut val[..]));
         acc.push((key, val));
     }
 
@@ -195,42 +206,44 @@ pub fn decode_headers<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Headers> {
 
 ///////////// Contexts codec functions
 
-pub fn encode_contexts(buffer: &mut Write, contexts: &Contexts) -> io::Result<()> {
+pub fn encode_contexts<W: Write + ?Sized>(writer: &mut W, contexts: &Contexts) -> io::Result<()> {
     if contexts.len() > u16::MAX as usize {
         return Err(io::Error::new(ErrorKind::InvalidInput, "Too many contexts to encode"));
-
     }
 
-    tryb!(buffer.write_u16::<BigEndian>(contexts.len() as u16));
-
+    // check our lengths before trashing the wire state
     for &(ref k, ref v) in contexts {
         if k.len() > u16::MAX as usize || v.len() > u16::MAX as usize {
             return Err(io::Error::new(ErrorKind::InvalidInput, "Context too large to encode"));
         }
+    }
 
-        tryb!(buffer.write_u16::<BigEndian>(k.len() as u16));
-        try!(buffer.write_all(&k[..]));
+    tryb!(writer.write_u16::<BigEndian>(contexts.len() as u16));
 
-        tryb!(buffer.write_u16::<BigEndian>(v.len() as u16));
-        try!(buffer.write_all(&v[..]));
+    for &(ref k, ref v) in contexts {
+        tryb!(writer.write_u16::<BigEndian>(k.len() as u16));
+        try!(writer.write_all(&k[..]));
+
+        tryb!(writer.write_u16::<BigEndian>(v.len() as u16));
+        try!(writer.write_all(&v[..]));
     }
 
     Ok(())
 }
 
-pub fn decode_contexts<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Contexts> {
-    let len = tryb!(buffer.read_u16::<BigEndian>()) as usize;
+pub fn decode_contexts<R: Read + ?Sized>(reader: &mut R) -> io::Result<Contexts> {
+    let len = tryb!(reader.read_u16::<BigEndian>()) as usize;
 
     let mut acc = Vec::with_capacity(len);
 
     for _ in 0..len {
-        let key_len = tryb!(buffer.read_u16::<BigEndian>());
+        let key_len = tryb!(reader.read_u16::<BigEndian>());
         let mut key = vec![0;key_len as usize];
-        try!(buffer.read_exact(&mut key[..]));
+        try!(reader.read_exact(&mut key[..]));
 
-        let val_len = tryb!(buffer.read_u16::<BigEndian>());
+        let val_len = tryb!(reader.read_u16::<BigEndian>());
         let mut val = vec![0;val_len as usize];
-        try!(buffer.read_exact(&mut val[..]));
+        try!(reader.read_exact(&mut val[..]));
         acc.push((key, val));
     }
 
@@ -238,9 +251,10 @@ pub fn decode_contexts<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Contexts>
 }
 
 ///////////// Dtab codec functions
+// TODO: optimize this...
 
-pub fn decode_dtab<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Dtab> {
-    let ctxs: Vec<(Vec<u8>, Vec<u8>)> = try!(decode_contexts(buffer));
+pub fn decode_dtab<R: Read + ?Sized>(reader: &mut R) -> io::Result<Dtab> {
+    let ctxs: Vec<(Vec<u8>, Vec<u8>)> = try!(decode_contexts(reader));
     let mut acc = Vec::with_capacity(ctxs.len());
 
     for (k, v) in ctxs {
@@ -252,12 +266,12 @@ pub fn decode_dtab<R: Read + ?Sized>(buffer: &mut R) -> io::Result<Dtab> {
     Ok(Dtab { entries: acc })
 }
 
-pub fn encode_dtab<R: Write + ?Sized>(buffer: &mut R, table: &Dtab) -> io::Result<()> {
-    tryb!(buffer.write_u16::<BigEndian>(table.entries.len() as u16));
+pub fn encode_dtab<W: Write + ?Sized>(writer: &mut W, table: &Dtab) -> io::Result<()> {
+    tryb!(writer.write_u16::<BigEndian>(table.entries.len() as u16));
 
     for &(ref k, ref v) in &table.entries {
-        try!(encode_u16_string(buffer, k));
-        try!(encode_u16_string(buffer, v));
+        try!(encode_u16_string(writer, k));
+        try!(encode_u16_string(writer, v));
     }
     Ok(())
 }
@@ -265,30 +279,34 @@ pub fn encode_dtab<R: Write + ?Sized>(buffer: &mut R, table: &Dtab) -> io::Resul
 ///////////// Rerr codec functions
 
 #[inline]
-pub fn decode_rerr<R: Read>(mut buffer: R) -> io::Result<String> {
+pub fn decode_rerr<R: Read>(mut reader: R) -> io::Result<String> {
     let mut data = Vec::new();
-    let _ = try!(buffer.read_to_end(&mut data));
+    let _ = try!(reader.read_to_end(&mut data));
     to_string(data)
 }
 
 ///////////// Init codec functions
 
-pub fn encode_init(buffer: &mut Write, msg: &Init) -> io::Result<()> {
-    tryb!(buffer.write_u16::<BigEndian>(msg.version));
+pub fn encode_init<W: Write + ?Sized>(writer: &mut W, msg: &Init) -> io::Result<()> {
+    tryb!(writer.write_u16::<BigEndian>(msg.version));
 
     for &(ref k, ref v) in &msg.headers {
-        tryb!(buffer.write_u32::<BigEndian>(k.len() as u32));
-        try!(buffer.write_all(k));
-        tryb!(buffer.write_u32::<BigEndian>(v.len() as u32));
-        try!(buffer.write_all(v));
+        tryb!(writer.write_u32::<BigEndian>(k.len() as u32));
+        try!(writer.write_all(k));
+        tryb!(writer.write_u32::<BigEndian>(v.len() as u32));
+        try!(writer.write_all(v));
     }
 
     Ok(())
 }
 
-pub fn decode_init(data: &[u8]) -> io::Result<Init> {
-    let datalen = data.len() as u64;
-    let mut buffer = Cursor::new(data);
+// TODO: optimize this.
+pub fn decode_init<R: Read>(mut reader: R) -> io::Result<Init> {
+    let mut buffer = Vec::new();
+    try!(reader.read_to_end(&mut buffer));
+    let datalen = buffer.len() as u64;
+
+    let mut buffer = Cursor::new(buffer);
 
     let version = tryb!(buffer.read_u16::<BigEndian>());
     let mut headers = Vec::new();
@@ -313,20 +331,20 @@ pub fn decode_init(data: &[u8]) -> io::Result<Init> {
 
 ///////////// Rdispatch codec functions
 
-pub fn encode_rdispatch(buffer: &mut Write, frame: &Rdispatch) -> io::Result<()> {
+pub fn encode_rdispatch<W: Write + ?Sized>(writer: &mut W, frame: &Rdispatch) -> io::Result<()> {
     let (status, body) = rmsg_status_body(&frame.msg);
 
-    tryb!(buffer.write_u8(status));
-    try!(encode_contexts(buffer, &frame.contexts));
-    buffer.write_all(body)
+    tryb!(writer.write_u8(status));
+    try!(encode_contexts(writer, &frame.contexts));
+    writer.write_all(body)
 }
 
 // Expects to consume the whole stream
-pub fn decode_rdispatch<R: Read>(mut buffer: R) -> io::Result<Rdispatch> {
-    let status = tryb!(buffer.read_u8());
-    let contexts = try!(decode_contexts(&mut buffer));
+pub fn decode_rdispatch<R: Read>(mut reader: R) -> io::Result<Rdispatch> {
+    let status = tryb!(reader.read_u8());
+    let contexts = try!(decode_contexts(&mut reader));
     let mut body = Vec::new();
-    let _ = try!(buffer.read_to_end(&mut body));
+    let _ = try!(reader.read_to_end(&mut body));
 
     Ok(Rdispatch {
         contexts: contexts,
@@ -336,28 +354,28 @@ pub fn decode_rdispatch<R: Read>(mut buffer: R) -> io::Result<Rdispatch> {
 
 ///////////// Rreq codec functions
 
-pub fn encode_rreq(buffer: &mut Write, frame: &Rmsg) -> io::Result<()> {
+pub fn encode_rreq<W: Write + ?Sized>(writer: &mut W, frame: &Rmsg) -> io::Result<()> {
     let (status, body) = rmsg_status_body(frame);
-    tryb!(buffer.write_u8(status));
-    buffer.write_all(body)
+    tryb!(writer.write_u8(status));
+    writer.write_all(body)
 }
 
-pub fn decode_rreq<R: Read>(mut buffer: R) -> io::Result<Rmsg> {
-    let status = try!(buffer.read_u8());
+pub fn decode_rreq<R: Read>(mut reader: R) -> io::Result<Rmsg> {
+    let status = try!(reader.read_u8());
     let mut body = Vec::new();
-    try!(buffer.read_to_end(&mut body));
+    try!(reader.read_to_end(&mut body));
     decode_rmsg_body(status, body)
 }
 
 ///////////// Tdispatch codec functions
 
-pub fn decode_tdispatch<R: Read>(mut buffer: R) -> io::Result<Tdispatch> {
-    let contexts = try!(decode_contexts(&mut buffer));
-    let dest = try!(decode_u16_string(&mut buffer));
-    let dtab = try!(decode_dtab(&mut buffer));
+pub fn decode_tdispatch<R: Read>(mut reader: R) -> io::Result<Tdispatch> {
+    let contexts = try!(decode_contexts(&mut reader));
+    let dest = try!(decode_u16_string(&mut reader));
+    let dtab = try!(decode_dtab(&mut reader));
 
     let mut body = Vec::new();
-    let _ = try!(buffer.read_to_end(&mut body));
+    let _ = try!(reader.read_to_end(&mut body));
 
     Ok(Tdispatch {
         contexts: contexts,
@@ -367,20 +385,20 @@ pub fn decode_tdispatch<R: Read>(mut buffer: R) -> io::Result<Tdispatch> {
     })
 }
 
-pub fn encode_tdispatch(buffer: &mut Write, msg: &Tdispatch) -> io::Result<()> {
-    try!(encode_contexts(buffer, &msg.contexts));
-    try!(encode_u16_string(buffer, &msg.dest));
-    try!(encode_dtab(buffer, &msg.dtab));
-    buffer.write_all(&msg.body)
+pub fn encode_tdispatch<W: Write + ?Sized>(writer: &mut W, msg: &Tdispatch) -> io::Result<()> {
+    try!(encode_contexts(writer, &msg.contexts));
+    try!(encode_u16_string(writer, &msg.dest));
+    try!(encode_dtab(writer, &msg.dtab));
+    writer.write_all(&msg.body)
 }
 
 ///////////// Treq codec functions
 
-pub fn decode_treq<R: Read>(mut buffer: R) -> io::Result<Treq> {
-    let headers = try!(decode_headers(&mut buffer));
+pub fn decode_treq<R: Read>(mut reader: R) -> io::Result<Treq> {
+    let headers = try!(decode_headers(&mut reader));
     let mut body = Vec::new();
 
-    let _ = try!(buffer.read_to_end(&mut body));
+    let _ = try!(reader.read_to_end(&mut body));
     Ok(Treq {
         headers: headers,
         body: body,
@@ -388,9 +406,9 @@ pub fn decode_treq<R: Read>(mut buffer: R) -> io::Result<Treq> {
 }
 
 #[inline]
-pub fn encode_treq(buffer: &mut Write, msg: &Treq) -> io::Result<()> {
-    try!(encode_headers(buffer, &msg.headers));
-    buffer.write_all(&msg.body)
+pub fn encode_treq<W: Write + ?Sized>(writer: &mut W, msg: &Treq) -> io::Result<()> {
+    try!(encode_headers(writer, &msg.headers));
+    writer.write_all(&msg.body)
 }
 
 #[inline]
@@ -418,21 +436,25 @@ fn decode_rmsg_body(status: u8, body: Vec<u8>) -> io::Result<Rmsg> {
 
 // decode a utf8 string with length specified by a u16 prefix byte
 #[inline]
-pub fn decode_u16_string<R: Read + ?Sized>(buffer: &mut R) -> io::Result<String> {
-    let str_len = tryb!(buffer.read_u16::<BigEndian>());
+pub fn decode_u16_string<R: Read + ?Sized>(reader: &mut R) -> io::Result<String> {
+    let str_len = tryb!(reader.read_u16::<BigEndian>());
     let mut s = vec![0; str_len as usize];
 
-    try!(buffer.read_exact(&mut s));
+    try!(reader.read_exact(&mut s));
 
     to_string(s)
 }
 
 #[inline]
-pub fn encode_u16_string<W: Write + ?Sized>(buffer: &mut W, s: &str) -> io::Result<()> {
+pub fn encode_u16_string<W: Write + ?Sized>(writer: &mut W, s: &str) -> io::Result<()> {
     let bytes = s.as_bytes();
-    assert!(bytes.len() <= u16::MAX as usize);
-    tryb!(buffer.write_u16::<BigEndian>(bytes.len() as u16));
-    buffer.write_all(bytes)
+    if bytes.len() <= u16::MAX as usize {
+        tryb!(writer.write_u16::<BigEndian>(bytes.len() as u16));
+        writer.write_all(bytes)
+    } else {
+        let msg = format!("u16 delimited String too long: {}", bytes.len());
+        Err(io::Error::new(ErrorKind::InvalidData, msg))
+    }
 }
 
 #[inline]

--- a/lib/mux/src/tests.rs
+++ b/lib/mux/src/tests.rs
@@ -55,8 +55,20 @@ fn roundtrip_frame(msg: MessageFrame) {
     let mut w = new_write();
     let _ = codec::encode_message(&mut w, &msg).unwrap();
     let w = w.into_inner();
-    let decoded = codec::read_message(&mut io::Cursor::new(w)).unwrap();
 
+    let mut two = Vec::new();
+
+    two.extend_from_slice(&w);
+    two.extend_from_slice(&w);
+
+    let mut buffer = io::Cursor::new(two);
+
+    // decode once
+    let decoded = codec::read_message(&mut buffer).unwrap();
+    assert_eq!(&msg, &decoded);
+
+    // decode it again to make sure we didn't consume too much data the first time
+    let decoded = codec::read_message(&mut buffer).unwrap();
     assert_eq!(&msg, &decoded);
 }
 


### PR DESCRIPTION
Functions that will consume an entire frame take a R: Read.
read_message utilizes `.take(size)` to limit the amount of buffer
that the frame codecs will consume.

Made names consistant:
parameters of type Read are called reader
parameters of type Write are called writer
