### PR TITLE
Upgrade byteorder dependency to 0.5.1

### DIFF
--- a/lib/mux/Cargo.toml
+++ b/lib/mux/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Bryce Anderson <bryce.anderson22@gmail.com>"]
 
 [dependencies]
-byteorder = "0.4.2"
+byteorder = "0.5.1"
 bit-set = "0.3.0"
 time = "0.1.34"


### PR DESCRIPTION
0.5.1 changes the error type to be io::Error, which is good because
their custom error was a bummer.
