### PR TITLE
Change style of matching to derefed types

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -138,21 +138,21 @@ pub fn encode_message<W: Write + ?Sized>(buffer: &mut W, msg: &Message) -> io::R
 /// assert_eq!(w.into_inner(), vec![]); // Tping is 0 length
 /// ```
 pub fn encode_frame<W: Write + ?Sized>(writer: &mut W, frame: &MessageFrame) -> io::Result<()> {
-    match frame {
-        &MessageFrame::Treq(ref f) => encode_treq(writer, f),
-        &MessageFrame::Rreq(ref f) => encode_rreq(writer, f),
-        &MessageFrame::Tdispatch(ref f) => encode_tdispatch(writer, f),
-        &MessageFrame::Rdispatch(ref f) => encode_rdispatch(writer, f),
-        &MessageFrame::Tinit(ref f) => encode_init(writer, f),
-        &MessageFrame::Rinit(ref f) => encode_init(writer, f),
+    match *frame {
+        MessageFrame::Treq(ref f) => encode_treq(writer, f),
+        MessageFrame::Rreq(ref f) => encode_rreq(writer, f),
+        MessageFrame::Tdispatch(ref f) => encode_tdispatch(writer, f),
+        MessageFrame::Rdispatch(ref f) => encode_rdispatch(writer, f),
+        MessageFrame::Tinit(ref f) => encode_init(writer, f),
+        MessageFrame::Rinit(ref f) => encode_init(writer, f),
         // the following are empty messages
-        &MessageFrame::Tping => Ok(()),
-        &MessageFrame::Rping => Ok(()),
-        &MessageFrame::Tdrain => Ok(()),
-        &MessageFrame::Rdrain => Ok(()),
-        &MessageFrame::Tdiscarded(ref msg) => encode_tdiscarded(writer, msg),
-        &MessageFrame::Tlease(ref d) => encode_tlease_duration(writer, d),
-        &MessageFrame::Rerr(ref msg) => encode_rerr(writer, msg),
+        MessageFrame::Tping => Ok(()),
+        MessageFrame::Rping => Ok(()),
+        MessageFrame::Tdrain => Ok(()),
+        MessageFrame::Rdrain => Ok(()),
+        MessageFrame::Tdiscarded(ref msg) => encode_tdiscarded(writer, msg),
+        MessageFrame::Tlease(ref d) => encode_tlease_duration(writer, d),
+        MessageFrame::Rerr(ref msg) => encode_rerr(writer, msg),
     }
 }
 
@@ -523,10 +523,10 @@ pub fn encode_treq<W: Write + ?Sized>(writer: &mut W, msg: &Treq) -> io::Result<
 
 #[inline]
 fn rmsg_status_body(msg: &Rmsg) -> (u8, &[u8]) {
-    match msg {
-        &Rmsg::Ok(ref body) => (0, body.as_ref()),
-        &Rmsg::Error(ref msg) => (1, msg.as_bytes()),
-        &Rmsg::Nack(ref msg) => (2, msg.as_bytes()),
+    match *msg {
+        Rmsg::Ok(ref body) => (0, body.as_ref()),
+        Rmsg::Error(ref msg) => (1, msg.as_bytes()),
+        Rmsg::Nack(ref msg) => (2, msg.as_bytes()),
     }
 }
 

--- a/src/codec/size.rs
+++ b/src/codec/size.rs
@@ -3,20 +3,20 @@ use super::super::*;
 // size related functions
 
 pub fn frame_size(frame: &MessageFrame) -> usize {
-    match frame {
-        &MessageFrame::Treq(ref f) => treq_size(f),
-        &MessageFrame::Rreq(ref f) => 1 + rmsg_size(f),
-        &MessageFrame::Tdispatch(ref f) => tdispatch_size(f),
-        &MessageFrame::Rdispatch(ref f) => rdispatch_size(f),
-        &MessageFrame::Tinit(ref f) => init_size(f),
-        &MessageFrame::Rinit(ref f) => init_size(f),
-        &MessageFrame::Tdrain => 0,
-        &MessageFrame::Rdrain => 0,
-        &MessageFrame::Tping => 0,
-        &MessageFrame::Rping => 0,
-        &MessageFrame::Tlease(_) => 9,
-        &MessageFrame::Tdiscarded(ref m) => 3 + m.msg.as_bytes().len(),
-        &MessageFrame::Rerr(ref msg) => msg.as_bytes().len(),
+    match *frame {
+        MessageFrame::Treq(ref f) => treq_size(f),
+        MessageFrame::Rreq(ref f) => 1 + rmsg_size(f),
+        MessageFrame::Tdispatch(ref f) => tdispatch_size(f),
+        MessageFrame::Rdispatch(ref f) => rdispatch_size(f),
+        MessageFrame::Tinit(ref f) => init_size(f),
+        MessageFrame::Rinit(ref f) => init_size(f),
+        MessageFrame::Tdrain => 0,
+        MessageFrame::Rdrain => 0,
+        MessageFrame::Tping => 0,
+        MessageFrame::Rping => 0,
+        MessageFrame::Tlease(_) => 9,
+        MessageFrame::Tdiscarded(ref m) => 3 + m.msg.as_bytes().len(),
+        MessageFrame::Rerr(ref msg) => msg.as_bytes().len(),
     }
 }
 
@@ -31,10 +31,10 @@ pub fn tdispatch_size(msg: &Tdispatch) -> usize {
 }
 
 pub fn rdispatch_size(msg: &Rdispatch) -> usize {
-    1 + context_size(&msg.contexts) + match &msg.msg {
-        &Rmsg::Ok(ref body) => body.len(),
-        &Rmsg::Error(ref msg) => msg.as_bytes().len(),
-        &Rmsg::Nack(ref msg) => msg.as_bytes().len(),
+    1 + context_size(&msg.contexts) + match msg.msg {
+        Rmsg::Ok(ref body) => body.len(),
+        Rmsg::Error(ref msg) => msg.as_bytes().len(),
+        Rmsg::Nack(ref msg) => msg.as_bytes().len(),
     }
 }
 
@@ -50,10 +50,10 @@ pub fn treq_size(treq: &Treq) -> usize {
 
 #[inline]
 pub fn rmsg_size(msg: &Rmsg) -> usize {
-    match msg {
-        &Rmsg::Ok(ref b) => b.len(),
-        &Rmsg::Error(ref m) => m.as_bytes().len(),
-        &Rmsg::Nack(ref m) => m.as_bytes().len(),
+    match *msg {
+        Rmsg::Ok(ref b) => b.len(),
+        Rmsg::Error(ref m) => m.as_bytes().len(),
+        Rmsg::Nack(ref m) => m.as_bytes().len(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,20 +122,20 @@ impl Dtab {
 
 impl MessageFrame {
     pub fn frame_id(&self) -> i8 {
-        match self {
-            &MessageFrame::Treq(_) => types::TREQ,
-            &MessageFrame::Rreq(_) => types::RREQ,
-            &MessageFrame::Tdispatch(_) => types::TDISPATCH,
-            &MessageFrame::Rdispatch(_) => types::RDISPATCH,
-            &MessageFrame::Tinit(_) => types::TINIT,
-            &MessageFrame::Rinit(_) => types::RINIT,
-            &MessageFrame::Tdrain => types::TDRAIN,
-            &MessageFrame::Rdrain => types::RDRAIN,
-            &MessageFrame::Tping => types::TPING,
-            &MessageFrame::Rping => types::RPING,
-            &MessageFrame::Tdiscarded(_) => types::TDISCARDED,
-            &MessageFrame::Tlease(_) => types::TLEASE,
-            &MessageFrame::Rerr(_) => types::RERR,
+        match *self {
+            MessageFrame::Treq(_) => types::TREQ,
+            MessageFrame::Rreq(_) => types::RREQ,
+            MessageFrame::Tdispatch(_) => types::TDISPATCH,
+            MessageFrame::Rdispatch(_) => types::RDISPATCH,
+            MessageFrame::Tinit(_) => types::TINIT,
+            MessageFrame::Rinit(_) => types::RINIT,
+            MessageFrame::Tdrain => types::TDRAIN,
+            MessageFrame::Rdrain => types::RDRAIN,
+            MessageFrame::Tping => types::TPING,
+            MessageFrame::Rping => types::RPING,
+            MessageFrame::Tdiscarded(_) => types::TDISCARDED,
+            MessageFrame::Tlease(_) => types::TLEASE,
+            MessageFrame::Rerr(_) => types::RERR,
         }
     }
 }


### PR DESCRIPTION
Before this commit many match statements were of the form

``` rust
match a_ref_type {
    &MessageFrame::Treq(ref f) => ...
}
```

etc. The more common syntax seems to be

``` rust
match *a_ref_type {
    MessageFrame::Treq(ref f) => ...
}
```

This commit converts matches to use the latter syntax.
