### PR TITLE
Improve documentation.

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,3 +1,9 @@
+//! Codec functions for encoding and decoding mux frames.
+//!
+//! Decode messages from a continuous stream using `read_message` to
+//! address message framing. Individual message decoding functions assume the
+//! remainder of the stream comprises the message.
+
 extern crate byteorder;
 
 use byteorder::{ReadBytesExt, BigEndian, WriteBytesExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Data structures representing the mux protocol.
+//!
+//! Package mux implements a generic RPC multiplexer with a rich protocol.
+//! Mux is itself encoding independent, so it is meant to use as the
+//! transport for other RPC systems (eg. thrift). In OSI terminology, it
+//! is a pure session layer.
+
 extern crate byteorder;
 
 mod dtab;
@@ -18,27 +25,32 @@ pub const MAX_TAG: u32 = (1 << 23) - 1;
 
 /// Id number and end flag for message frames.
 ///
-/// Every message has a `Tag` following the frame length and frame
-/// type on the wire. The frame id is limited to 23 bits of precision
-/// while bit 24 signals if the message stream is ending. This only
-/// applies to the `Tdispatch` and `Rdispatch` frames.
+/// Every message has an associated `Tag` following the frame length and frame
+/// type on the wire. The frame id represents the stream identifier and is limited
+/// to 23 bits of precision while bit 24 signals if the message stream is ending.
+/// This only applies to the `Tdispatch` and `Rdispatch` frames.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Tag {
+    /// Signal that this frame is the end of the stream of fragments.
+    ///
+    /// Currently, only Tdispatch and Rdispatch messages may be split into an
+    /// ordered sequence of fragments. TdispatchError message ends a Tdispatch
+    /// sequence and an Rerr ends an Rdispatch sequence.
     pub end: bool,
+    /// Identification number associated with this stream.
     pub id: u32,
 }
 
-/// An entire mux packet.
-///
-/// The `Message` type contains enough information to encode an
-/// entire packet.
+/// Representation of an entire mux packet.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Message {
+    /// Identification and termination information about the associated stream.
     pub tag: Tag,
+    /// Payload of the message. The length is determined from the payload.
     pub frame: MessageFrame,
 }
 
-/// Wrapper of the various mux packet types.
+/// Type wrapper for the mux packet representations.
 #[derive(Debug, PartialEq, Eq)]
 pub enum MessageFrame {
     Treq(Treq),
@@ -61,14 +73,16 @@ pub enum MessageFrame {
 /// Representation of the mux `Treq` types.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Treq {
+    /// Request headers.
     pub headers: Headers,
+    /// Body of the request.
     pub body: Vec<u8>,
 }
 
 /// Representation of a mux `Rreq` and `Rdispatch` message body.
 #[derive(PartialEq, Eq, Debug)]
 pub enum Rmsg {
-    /// Successful response.
+    /// Successful response containing a body.
     Ok(Vec<u8>),
     /// Response failed. The `String` describes the error.
     Error(String),
@@ -79,42 +93,75 @@ pub enum Rmsg {
 /// Representation of a mux `Tdispatch` frame.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Tdispatch {
+    /// Context information associated with this request.
     pub contexts: Contexts,
+    /// Destination of this request.
     pub dest: String,
+    /// Table of delegation rules for 'rewriting' the destination.
     pub dtab: Dtab,
+    /// Message payload.
     pub body: Vec<u8>,
 }
 
 /// Representation of a mux `Rdispatch` frame.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Rdispatch {
+    /// Context information associated with this request.
     pub contexts: Contexts,
+    /// Response of the dispatch request.
     pub msg: Rmsg,
 }
 
 /// Representation of a mux `Tinit` and `Rinit` frame.
+///
+/// `Tinit` and `Rinit` frames are used for negotiation of the mux protocol
+/// version and behavior. A `Tinit` is typically sent by the client at the
+/// beginning of the session. Until a `Rinit` is received the client cannot
+/// issue any more T messages. Once the `Rinit` is received, the session state
+/// is considered reset. The version return in `Rinit` is the accepted protocol
+/// version and may be lower than that of the issued `Tinit`.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Init {
+    /// Mux protocol version.
     pub version: u16,
+    /// Additional negotiation related information.
     pub headers: Contexts,
 }
 
 /// Representation of a mux `Tdiscarded` frame.
+///
+/// A `Tdiscarded` frame is a marker message alerting the server that the
+/// client has discarded the `Tdispatch` issued with the associated id. This
+/// does not free the server from the obligation of replying to the origional
+/// request.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Tdiscarded {
+    /// Stream id of the discarded `Tdispatch` request.
     pub id: u32,
+    /// Reason for discarding the request.
     pub msg: String,
 }
 
 /// Representation of a mux `Tlease` frame.
+///
+/// A `Tlease` is a marker message that is issued to alert the client that
+/// it has been allocated resources for a specific duration. In the abscence
+/// of a `Tlease`, the client assumes it holds an indefinate lease.
+/// Adhering to the lease is optional but the server may reject requests or
+/// operate at a degraded capacity under and expired lease.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Tlease {
+    /// `Duration` of the lease allocated to the client.
     pub duration: Duration,
 }
 
 /// Representation of a mux `Rerr` frame.
+///
+/// An `Rerr` is sent from the server in the even that the server failed to
+/// interpret or act on a request T message.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Rerr {
+    /// Description of the error.
     pub msg: String,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,11 @@
+//! Wire identification tag of the mux message types.
+//!
+//! The encoding of these tags is two's compliment one-byte integer
+//! where positive integers are T-messages and their negative compliment
+//! are the coresponding R-messages. T-messages greater than 63 are
+//! consider session control messages along with their R-message compliment
+//! while all other messages are consider application messages.
+
 pub const TREQ: i8 = 1;
 pub const RREQ: i8 = -1;
 


### PR DESCRIPTION
Added more type level documentation as well as some module level
information about the protocol. Most of the information mirrors the
content of the official mux specification described in
https://github.com/twitter/finagle/blob/develop/finagle-mux/src/main/scala/com/twitter/finagle/mux/package.scala
 (commit d21fe77b7445cd9732a57980661e56f0e75bb91b).
