### PR TITLE
Move tests outside of the mux package.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,10 +206,3 @@ impl Tdispatch {
         }
     }
 }
-
-
-#[cfg(test)]
-mod tests;
-
-#[cfg(test)]
-mod conformance;

--- a/tests/binary_conformance.rs
+++ b/tests/binary_conformance.rs
@@ -1,12 +1,13 @@
+extern crate mux;
 
 use std::fmt::Debug;
 use std::io;
 use std::io::Cursor;
 use std::time::Duration;
 
-use super::*;
-use codec::*;
-use codec::size::*;
+use mux::*;
+use mux::codec::*;
+use mux::codec::size::*;
 
 const BUFFER_STR: &'static str = "hello world";
 

--- a/tests/packet_roundtrip.rs
+++ b/tests/packet_roundtrip.rs
@@ -1,7 +1,7 @@
-use super::*;
+extern crate mux;
 
+use mux::*;
 use std::io;
-
 
 static TDISPATCH_BUF: &'static [u8] = &[
     0, 0, 0, 65, // frame size


### PR DESCRIPTION
They are now what are considered 'integration tests'.
http://doc.crates.io/manifest.html#integration-tests
