### PR TITLE
Update makefile and drop bugfix version number of dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ exclude = ["./examples"]
 debug = true
 
 [dependencies]
-byteorder = "0.5.1"
+byteorder = "0.5"

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,13 @@
 PKG_NAME=mux
 
-# CARGO_FLAGS
-
-all: build test doc
+all: doc build test
 
 .PHONY: run test build clean
 run test build clean:
 	cargo $@ $(CARGO_FLAGS)
 
 .PHONY: doc
-doc:
-	rm -rf target/doc
+doc: clean
 	cargo doc
 	echo '<meta http-equiv="refresh" content="0;url='${PKG_NAME}'/index.html">' > target/doc/index.html
 
@@ -22,4 +19,3 @@ docview: doc
 publishdoc: doc
 	ghp-import -n target/doc
 	git push -f origin gh-pages
-


### PR DESCRIPTION
The makefile wasn't building the docs without a clean command first.
There was no need to enforce version 0.5.1 for byteorder as oppose to 0.5
